### PR TITLE
Add missing required extension

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -27,6 +27,7 @@ The Lavalite framework has a few system requirements.
     - Fileinfo PHP Extension
     - GD Library
     - Imagick PHP Extension
+    - GMP PHP Extension
 
 <a name="install-lavalite"></a>
 ### Installing Lavalite


### PR DESCRIPTION
The GMP extension is required for the app to run, however it is not stated as a requirement.

Attempting to serve the app without installing php-gmp results in this error.

![Screenshot from 2022-11-20 18-04-42](https://user-images.githubusercontent.com/26435307/202912975-d50fc4d6-7073-4a58-8b1f-f4612d1a176a.png)
